### PR TITLE
[bugfix] 브라우저 종료 시에도 주차 상태 업데이트를 보장하는 서비스 추가

### DIFF
--- a/src/api/service/mySpotService.ts
+++ b/src/api/service/mySpotService.ts
@@ -1,10 +1,11 @@
+import { BASE_URL } from '../../config/URL.ts';
 import { MySpotState } from '../../types/states.ts';
 import axiosInstance from '../axiosInstance.ts';
 
 /**
  * 특정 사용자의 예약 상태를 업데이트하는 서비스
  * @param userId - 사용자 ID
- * @param parkingSpotId - 예약할 주차 면 ID
+ * @param parkingSpotId - 업데이트할 주차 면 ID
  * @param status - 예약 상태 ('예약', '점유', '비점유')
  * @returns 업데이트된 MySpotState
  */
@@ -45,6 +46,36 @@ export const fetchMySpotService = async (
         return response.data[0]; // 첫 번째 사용자 데이터 반환
     } catch (error) {
         console.error('Failed to fetch my spot:', error);
+        throw error;
+    }
+};
+
+/**
+ * 업데이트 요청이 브라우저 종료 시에도 서버로 전달되도록 보장하는 서비스
+ *
+ * @param id - 사용자 ID
+ * @param parkingSpotId - 업데이트할 주차 면 ID
+ * @param status - 예약 상태
+ *
+ * fetch API의 keepalive: true 옵션을 사용하여
+ * 브라우저 종료나 탭 닫힘 상황에서도 네트워크 요청이 완료되도록 보장
+ * 페이로드 크기가 약 64KB로 제한되며, 큰 요청에는 적합하지 않습니다.
+ */
+export const updateMySpotServiceKeepAlive = async ({
+    id,
+    parkingSpotId,
+    status,
+}: MySpotState): Promise<void> => {
+    try {
+        const payload = JSON.stringify({ parkingSpotId, status });
+        await fetch(`${BASE_URL}/parkingReservations/${id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: payload,
+            keepalive: true, // 두 번째 인수로 설정 객체만 전달
+        });
+    } catch (error) {
+        console.error('Failed to update mySpot with keepalive:', error);
         throw error;
     }
 };

--- a/src/components/ReservePage.tsx
+++ b/src/components/ReservePage.tsx
@@ -9,6 +9,7 @@ import { useUpdateParkingSpotMutation } from '../redux/apis/parkingSpotsApi.ts';
 import Button from './Button.tsx';
 import useHandleBeforeUnload from '../hooks/useHandleBeforeUnload.tsx';
 import Timer from './Timer.tsx';
+import { updateMySpotServiceKeepAlive } from '../api/service/mySpotService.ts';
 
 const ReservePage: React.FC = () => {
     const { id } = useParams<{ id: string }>();
@@ -23,12 +24,12 @@ const ReservePage: React.FC = () => {
     useHandleBeforeUnload({
         condition: mySpot.status === '예약', // "예약" 상태일 때만 실행
         onUnload: () => {
-            updateMySpot({
-                id: 'user',
-                parkingSpotId: mySpot.parkingSpotId!,
+            updateParkingSpot({ id: mySpot.parkingSpotId!, status: '비점유' });
+            updateMySpotServiceKeepAlive({
+                id: mySpot.id!,
+                parkingSpotId: null,
                 status: '비점유',
             });
-            updateParkingSpot({ id: mySpot.parkingSpotId!, status: '비점유' });
         },
     });
 


### PR DESCRIPTION
- 브라우저 종료나 탭 닫힘 상황에서도 주차 상태가 서버로 전달되도록 `updateMySpotServiceKeepAlive` 함수 추가
  - fetch API의 keepalive: true 옵션을 사용하여 네트워크 요청이 중단되지 않도록 구현
    - 오류 발생 시 디버깅을 위한 예외 처리 로직 추가